### PR TITLE
New error message if command line switch '-t' is used but given path does not exist.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+opbasm.egg-info/
+build/
+dist/

--- a/opbasm.py
+++ b/opbasm.py
@@ -114,7 +114,7 @@ except ImportError:
   def warn(t): return t
   def error(t): return t
 
-__version__ = '1.2.10'
+__version__ = '1.2.11'
 
 
 class FatalError(Exception):
@@ -1983,6 +1983,9 @@ def find_templates(template_file):
         templates['vhdl'] = template_file
       else:
         templates['verilog'] = template_file
+    else:
+      print(_('Given template file \'{}\' does not exist.').format(template_file))
+      sys.exit(1)
 
   else: # Search for standard templates
     vhdl_templates = ('ROM_form.vhd', 'ROM_form.vhdl')


### PR DESCRIPTION
Added:
- New error message if command line switch '-t' is used but given path does not exist.
- Changed version to 1.2.11 (this was not done at the last feature update (jump tables)
- Added .gitignore file:
  - Ignore all generated files from setup.py run.