### PR TITLE
Fix race condition when running parallel opbasm instances with m4.

### DIFF
--- a/opbasm/opbasm.py
+++ b/opbasm/opbasm.py
@@ -37,6 +37,7 @@ import io
 import re
 import gettext
 import hashlib
+import uuid
 
 import  opbasm.optimize as optimize
 
@@ -606,7 +607,7 @@ class Assembler(object):
     '''
     self.create_output_dir() # Make sure directory exists for generated source
 
-    pp_source_file = os.path.splitext(source_file)[0] + '.gen.psm'
+    pp_source_file = os.path.splitext(source_file)[0] + uuid.uuid4().hex + '.gen.psm'
     pp_source_file = build_path(self.config.output_dir, pp_source_file)
 
     # Look for common picoblaze.m4 macro definitions


### PR DESCRIPTION
Prior to the patch, opbasm used a single preprocessor filename (source_file.gen.psm) that could correspond to distinct generated content (e.g. with -D macros). This filename represents a race condition when many opbasm instances are invoked in parallel.

This patch uses uuid.uuid4 to uniquify the filename associated with the preprocessed assembly code.
contain different contents